### PR TITLE
Add project references for workers to main project

### DIFF
--- a/src/main/tsconfig.json
+++ b/src/main/tsconfig.json
@@ -4,5 +4,9 @@
     "lib": ["esnext", "dom"],
     "outDir": "../../dist/main"
   },
+  "references": [
+    {"path": "../../src/dedicated-worker"},
+    {"path": "../../src/service-worker"}
+  ],
   "include": ["./**/*"]
 }


### PR DESCRIPTION
This fixes the error when referencing the dedicated worker from the main project:
> error TS6059: File 'src/dedicated-worker/index.ts' is not under 'rootDir' 'src/main'.
