### PR TITLE
Fix composite project setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b src/main"
   },
   "devDependencies": {
     "typescript": "^3.4.5"

--- a/src/dedicated-worker/tsconfig.json
+++ b/src/dedicated-worker/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["esnext", "webworker"],
-    "outDir": "../../dist/dedicated-worker"
   },
   "include": ["./**/*"]
 }

--- a/src/main/tsconfig.json
+++ b/src/main/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["esnext", "dom"],
-    "outDir": "../../dist/main"
   },
+  "references": [
+    {"path": "../dedicated-worker"},
+    {"path": "../service-worker"},
+  ],
   "include": ["./**/*"]
 }

--- a/src/service-worker/tsconfig.json
+++ b/src/service-worker/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["esnext", "webworker"],
-    "outDir": "../../dist/service-worker"
   },
   "include": ["./**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,8 @@
     "module": "esnext",
     "strict": true,
     "moduleResolution": "node",
+    "rootDir": "src",
+    "outDir": "dist",
     "composite": true
   },
-  "references": [
-    {"path": "src/main"},
-    {"path": "src/dedicated-worker"},
-    {"path": "src/service-worker"},
-  ],
-  "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
Another attempt! 😛 
* Make `main` the "root project", i.e. run `tsc -b src/main` (instead of `tsc -b`)
* Specify `rootDir` and `outDir` once in the top-level shared `tsconfig`
* Specify the project references in `main` because they are not inherited through `extends`, see microsoft/TypeScript#27098

That seems to fix all build-related errors. There are still type errors because of microsoft/TypeScript#14877, but you could work around that with something like `self as DedicatedWorkerGlobalScope`.