### PR TITLE
Use empty export list instead of unused export

### DIFF
--- a/src/dedicated-worker/index.ts
+++ b/src/dedicated-worker/index.ts
@@ -3,7 +3,7 @@
 
 // This fixes `self`'s type.
 declare var self: DedicatedWorkerGlobalScope;
-export type unused = 'unused';
+export {};
 
 const helloMessage = {
   hello: 'world',

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -3,7 +3,7 @@
 
 // This fixes `self`'s type.
 declare var self: ServiceWorkerGlobalScope;
-export type unused = 'unused';
+export {};
 
 console.log(self.clients);
 


### PR DESCRIPTION
This way the file is still parsed as a module, even though it doesn't `import` or `export` anything. 😉